### PR TITLE
#143 fix link to getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The OBOOK is the main resource for OBOAcademy training materials for Semantic OBO Engineers.
 
-- To get started with learning: https://oboacademy.github.io/obook/getting_started/
+- To get started with learning: https://oboacademy.github.io/obook/getting-started/
 - To contribute: https://oboacademy.github.io/obook/contributing/
 
 ## License


### PR DESCRIPTION
The link in README.md to https://oboacademy.github.io/obook/getting_started/ didn't quite look right. getting-started (with a dash, not underscore) looks much better. I'm not sure why the underscore partially works though.