### PR TITLE
Use canonical form for true in yaml

### DIFF
--- a/docs/tutorial/dosdp-odk.md
+++ b/docs/tutorial/dosdp-odk.md
@@ -57,7 +57,7 @@ robot_java_args: '-Xmx8G'
 In your `src/ontology/{yourontology}-odk.yaml` file, simply add the following:
 
 ```yaml
-use_dosdps: TRUE
+use_dosdps: true
 ```
 
 This flag activates DOSDP in ODK - without it, none of the DOSDP workflows in ODK can be used. Technically, this flag tells ODK the following things:


### PR DESCRIPTION
Always use canonical forms `true` and `false` for bools in YAML

This will ensure future proofing for yaml 1.2, frameworks like rueyaml, etc

The status of non-canonical forms in 1.2 is a little unclear

https://stackoverflow.com/questions/42283732/are-on-and-off-supposed-to-be-interpreted-as-true-or-false-in-yaml-1-2