### PR TITLE
Update Taxon restriction documents

### DIFF
--- a/docs/explanation/taxon-constraints-explainer.md
+++ b/docs/explanation/taxon-constraints-explainer.md
@@ -21,6 +21,40 @@ E.g. when GO implemented taxon restrictions, they found 5874 errors [PMID:209739
 
 3. Querying
    E.g. in Brain Data Standards, in_taxon axioms that allow faceting cell types by species. (note: there are limitations on this and may be incomplete)
+      
+## Types of Taxon Restrictions 
+
+There are, in essence, three categories of taxon-specific knowledge we use across OBO ontologies. Given a class `C`, which could be anything from an anatomical entity to a biological process, we have the following categories:
+
+
+1. The ALL-IN restriction: "C in-taxon T"
+2. The NOT-IN restriction: "C never-in-taxon T"
+3. The SOME-IN restriction: "C present-in-taxon T"
+
+#### The ALL-IN restriction: "in-taxon some T"
+
+- _Meaning_: "_All_ instances of `C` are in taxon `T`"
+- _Canonical logical representation_: `C SubClassOf: in-taxon some T` 
+   - Comment: no need for only-in-taxon if in-taxon is functional
+- _Alternative representations_: None
+- _Editor guidance_:  Editors use the Cannonical logical representation in subClassOf or simple (non-nested) EquivalentClass axioms.
+
+#### The NOT-IN restriction: "C SubClassOf: not (in_taxon some T)"
+
+- _Meaning_: "_No_ instances of `C` are in taxon `T`"
+- _Canonical logical representation_: `C SubClassOf: not (in_taxon some T)` 
+- _Alternative representations_:
+   - Alternative EL logical representation: `C disjointWith in-taxon some T`
+   - Canonical Shortcut: AnnotationAssertion: `C never-in-taxon T` # Editors use this
+- _Editor guidance_: Editors use the canonical shorcut (annotation axiom). 
+
+#### The SOME-IN restriction: "a ClassAssertion: `C` and in-taxon some `T`"
+
+- _Meaning_: "_At least one specific_ instance of `C` is in taxon `T`". 
+- _Canonical logical representation_: `IND:a Type: C and in-taxon some T`
+- _Alternative representations_:
+   - Canonical shortcut: AnnotationAssertion: `C present-in-taxon T` # Editors use this
+- _Editor guidance_: Editors use the canonical shorcut (annotation axiom).  The taxon should be as specific as possible, ideally a species.
 
 ## How to add taxon restrictions:
 

--- a/docs/howto/add-taxon-restrictions.md
+++ b/docs/howto/add-taxon-restrictions.md
@@ -1,5 +1,7 @@
 # Adding taxon restrictions
 
+Before adding taxon restrictions, please review the [types of taxon restrictions documentation](../explanation/taxon-constraints-explainer/#Types-of-Taxon-Restrictions).
+
 See [Daily Workflow](daily-curator-workflow.md) for creating branches and basic Protégé instructions.
 
 1. `in taxon` relations are added as `Subclasses`.


### PR DESCRIPTION
As mentioned in CL call - this is the update for obook taxon documentation. 
@bvarner-ebi will add CL specific stuff in CL docs (eg label conventions) and link to this for more general stuff. 