### PR TITLE
correct protege spelling

### DIFF
--- a/docs/lesson/ontology-fundamentals.md
+++ b/docs/lesson/ontology-fundamentals.md
@@ -6,7 +6,7 @@ These materials are under construction and incomplete.
 
 ## Prerequisites
 
-- Install Protege
+- Install Protégé
 
 ## Preparation
 


### PR DESCRIPTION
Corrected the spelling of Protégé so it is consistent throughout the whole document. Checked all links to ensure they are working.