### PR TITLE
Add Guide to Taxon Restrictions link to schedule

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -26,7 +26,7 @@ The goal of this course is to provide ongoing training for the OBO community. As
 
 | Date       | Lesson                                                                                                                  | Notes                                                                                                                                                                                                                                                                                                                | Recordings                                                           |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| 2022/01/10 | Modelling with taxon constraints | Jim Balhoff tutorial |
+| 2023/01/10 | [Modeling with taxon constraints](https://oboacademy.github.io/obook/explanation/taxon-constraints-explainer/) | Jim Balhoff tutorial |
 | 2022/12/27 | _No Meeting_ | Enjoy the Holidays! |
 | 2022/12/13 | [Introduction to Semantic Entity Matching](../lesson/entity-matching.md) | [slides](https://bit.ly/obo-academy-semantic-matching) |
 | 2022/11/29 | [OBO Academy hackathon](../lesson/hackathon.md) | Work on open tickets together.  |


### PR DESCRIPTION
Jim Balhoff completed the tutorial content update for the 2023-01-10 tutorial on Modeling Taxon Constraints. This update adds the link to the lecture content on the OBO Academy schedule. https://oboacademy.github.io/obook/explanation/taxon-constraints-explainer/