### PR TITLE
Add link to the Protégé 5.6 tutorial slides.

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -32,7 +32,7 @@ _Note: this is tentative and subject to change_
 | 2023/05/30 | Idea: Leveraging ChatGPT during ontology curation | TBD | |
 | 2023/05/16 | Cancelled (Monarch-Cpath workshop) | | |
 | 2023/05/02 | Cancelled (No meeting week) |   | |
-| 2023/04/18 | Overview of Protege 5.6 - the latest features | Tutorial by Damien Goutte-Gattat  | |
+| 2023/04/18 | Overview of Protege 5.6 - the latest features | Tutorial by Damien Goutte-Gattat ([slides](https://docs.google.com/presentation/d/1fScxL59EL4YOYe6uNJnR9TCy72kOAkIxLH-HHDfRTKw/edit?usp=sharing))  | |
 | 2023/04/04 | [Introduction to Exomiser](../tutorial/exomiser-tutorial.md) | Tutorial by Valentina, Yasemin and Carlo from QMUL.  | |
 | 2023/03/21 | Introduction to Wikidata | Tutorial by experts in the field Andra Waagmeester and Tiago Lubiana  | [Here](https://youtu.be/KonJqKquUSU) |
 | 2023/03/07 | OAK for the Ontology Engineering community | Chris Mungall tutorial | [Here](https://youtu.be/zO6tS7gZtvw) |


### PR DESCRIPTION
Update the Monarch OBO Training page to add a link to the supporting slides for the April 2023 “Overview of Protégé 5.6” tutorial.