### PR TITLE
fixed typo, made some phrasing parallel

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,16 +134,16 @@ nav:
           - Dealing with Large Ontologies: howto/deal-with-large-ontologies.md
           - Updating Imports with ODK: howto/update-import.md
           - Import ORCIDIO: howto/odk-add-orcidio-module.md
-      - Git and Github:
+      - Git and GitHub:
           - Make term requests to existing ontologies: howto/term-request.md
           - Clone a repository: howto/clone-mondo-repo.md
           - Fork an ontology for editing: howto/github-create-fork.md
-          - Creating an GitHub Pull Request: howto/github-create-pull-request.md
+          - Create a GitHub Pull Request: howto/github-create-pull-request.md
           - Change a pull request: howto/change-files-pull-request.md
-          - Fixing conflicts: howto/fixing-conflicts.md
-          - Github actions to automate tasks: howto/github-actions.md
+          - Fix conflicts: howto/fixing-conflicts.md
+          - Automate tasks with GitHub actions: howto/github-actions.md
           - Revert a commit: howto/revert-commit.md
-          - Review pull request: howto/review-pull-request.md
+          - Review a pull request: howto/review-pull-request.md
       - Quality control:
           - Deploy a custom OBO-Dashboard: howto/deploy-custom-obo-dashboard.md
       - Command line:


### PR DESCRIPTION
i came here to fix the typo "an GitHub" but while i was at it, i changed a few words in that section of the document to make the bullet points more parallel. note that there are many other places i did not update, but that would benefit from a similar unification of style -- for example, in the section before the one i edited, there are points "Updating Imports" and "Import ORCIDIO". the first of those could be rephrased "Update imports" or the second could be "Importing ORCIDIO".