### PR TITLE
Update schedule to cancel Nov 28, 2023

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -32,7 +32,7 @@ _Note: this is tentative and subject to change_
 | 2024/01/09 | Cancelled: Winter break | No one (or everyone) | |
 | 2023/12/26 | Cancelled: Winter break | No one | |
 | 2023/12/12 | Introduction to DOSDP pattern design and workflows | Ray Stefancsik | |
-| 2023/11/28 | Standardising metadata in OBO ontologies: from definitions and contribution to synonym types. Best practices. | Anita Caron | |
+| 2023/11/28 | No meeting this week | | |
 | 2023/11/14 | Enhancing curation workflows with CurateGPT | Chris Mungall | |
 | 2023/10/31 | Cancelled: No meeting week | No one | |
 | 2023/10/17 | [Using ontologies for data annotation and consequences for ontology development](https://docs.google.com/presentation/d/16Bd1szeJ-gaSuKWJhVJRHYrwdZ4LtjIAPSIqP9OveFc/edit?usp=sharing) | Sabrina Toro | [Here](https://youtu.be/jRB5VTJLOGc?feature=shared)|


### PR DESCRIPTION
Updated the schedule to cancel the Nov 28, 2023 OBO Academy with Anita Caron on _OBO metadata standardisation_. This will be rescheduled for the early 2024. 