### PR TITLE
Update tutorial title & presenters for April 2, 2024

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -29,7 +29,7 @@ _Note: this is tentative and subject to change_
 | Date | Lesson | Notes | Recordings |
 | --- | --- | --- | --- |
 | 2024/04/16 | AI-assisted ontology editing workflows 2 | Chris Mungall |
-| 2024/04/02 | Synonym Type curation - a deep dive | Trish Whetzel, CU |
+| 2024/04/02 | OBO Academy Phenomics Series: Phenotype data and the role of ontologies | James McLaughlin (EBML-EBI) and Nico Matentzoglu |
 | 2024/03/19 | _No Meeting_ |  |
 | 2024/03/05 | AI-assisted ontology editing workflows 1 | Chris Mungall | [Here](https://www.youtube.com/watch?v=wGoGr2dmxZI) |
 | 2024/02/20 | [Ontology Metadata Standardisation](https://docs.google.com/presentation/d/12ig7zQ9R4lQAybuTQKb73gB22pIq5MEaowwbYOl5Ei8/edit?usp=sharing) | Anita Caron, EBI | [Here](https://youtu.be/tso8zawC3Tw?feature=shared)


### PR DESCRIPTION
Updated the tutorial for April 2, 2024 to be OBO Academy Phenomics Series: Phenotype data and the role of ontologies led by James McLaughlin (EBML-EBI) and Nico Matentzoglu