### PR TITLE
Add links to slides or OBO page for OBO academy schedule

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -28,10 +28,10 @@ _Note: this is tentative and subject to change_
 
 | Date | Lesson | Notes | Recordings |
 | --- | --- | --- | --- |
-| 2024/04/16 | AI-assisted ontology editing workflows 2 | Chris Mungall |
-| 2024/04/02 | OBO Academy Phenomics Series: Phenotype data and the role of ontologies | James McLaughlin (EBML-EBI) and Nico Matentzoglu |
+| 2024/04/16 | [AI-assisted ontology editing workflows 2: Validation](https://docs.google.com/presentation/d/13Hlm-iJo7a1NAaUqLsrUlbn-tLUVbF25WBjwAgIuLdA/edit#slide=id.g2cbabe5fcdf_0_5) | Chris Mungall, LBNL |
+| 2024/04/02 | OBO Academy Phenomics Series: [Phenotype data and the role of ontologies](https://oboacademy.github.io/obook/lesson/phenotype-data/) | James McLaughlin (EBML-EBI) and Nico Matentzoglu | 
 | 2024/03/19 | _No Meeting_ |  |
-| 2024/03/05 | AI-assisted ontology editing workflows 1 | Chris Mungall | [Here](https://www.youtube.com/watch?v=wGoGr2dmxZI) |
+| 2024/03/05 | [AI-assisted ontology editing workflows 1: generating and augmenting](https://docs.google.com/presentation/d/13Hlm-iJo7a1NAaUqLsrUlbn-tLUVbF25WBjwAgIuLdA/edit#slide=id.g24560ef6bb7_0_84) | Chris Mungall, LBNL | [Here](https://www.youtube.com/watch?v=wGoGr2dmxZI) |
 | 2024/02/20 | [Ontology Metadata Standardisation](https://docs.google.com/presentation/d/12ig7zQ9R4lQAybuTQKb73gB22pIq5MEaowwbYOl5Ei8/edit?usp=sharing) | Anita Caron, EBI | [Here](https://youtu.be/tso8zawC3Tw?feature=shared)
 | 2024/02/06 | [Introduction to Open Source licenses](../lesson/licensing-data-and-software.md) | Seth Carbon, LBNL |
 | 2024/01/23 | Bridge2AI data standards: a practical introduction | Harry Caufield, LBNL | [Here](https://youtu.be/zaZtcDbjqTw?feature=shared)


### PR DESCRIPTION
Adding links to the OBO page or slides for the AI-assisted ontology editing tutorials and the phenotype series tutorial (March and April 2024). 