### PR TITLE
Update OBO Academy schedule

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -28,6 +28,7 @@ _Note: this is tentative and subject to change_
 
 | Date | Lesson | Notes | Recordings |
 | --- | --- | --- | --- |
+| 2024/05/13 | Introduction to the legendary [Uberon Anatomy ontology](https://obophenotype.github.io/uberon/) | Damien Goutte-Gattat and Nico Matentzoglu |  |
 | 2024/04/30 | [An Introduction to Synonyms in OBO Ontologies](https://oboacademy.github.io/obook/lesson/synonyms/) | Nicole Vasilevsky, C-Path | 
 | 2024/04/16 | [AI-assisted ontology editing workflows 2: Validation](https://docs.google.com/presentation/d/13Hlm-iJo7a1NAaUqLsrUlbn-tLUVbF25WBjwAgIuLdA/edit#slide=id.g2cbabe5fcdf_0_5) | Chris Mungall, LBNL |
 | 2024/04/02 | OBO Academy Phenomics Series: [Phenotype data and the role of ontologies](https://oboacademy.github.io/obook/lesson/phenotype-data/) | James McLaughlin (EBML-EBI) and Nico Matentzoglu | [Here](https://youtu.be/9iWRRx7nZlU?feature=shared)

--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -28,7 +28,7 @@ _Note: this is tentative and subject to change_
 
 | Date | Lesson | Notes | Recordings |
 | --- | --- | --- | --- |
-| 2024/05/13 | Introduction to the legendary [Uberon Anatomy ontology](https://obophenotype.github.io/uberon/) | Damien Goutte-Gattat and Nico Matentzoglu |  |
+| 2024/05/14 | Introduction to the legendary [Uberon Anatomy ontology](https://obophenotype.github.io/uberon/) | Damien Goutte-Gattat and Nico Matentzoglu |  |
 | 2024/04/30 | [An Introduction to Synonyms in OBO Ontologies](https://oboacademy.github.io/obook/lesson/synonyms/) | Nicole Vasilevsky, C-Path | 
 | 2024/04/16 | [AI-assisted ontology editing workflows 2: Validation](https://docs.google.com/presentation/d/13Hlm-iJo7a1NAaUqLsrUlbn-tLUVbF25WBjwAgIuLdA/edit#slide=id.g2cbabe5fcdf_0_5) | Chris Mungall, LBNL |
 | 2024/04/02 | OBO Academy Phenomics Series: [Phenotype data and the role of ontologies](https://oboacademy.github.io/obook/lesson/phenotype-data/) | James McLaughlin (EBML-EBI) and Nico Matentzoglu | [Here](https://youtu.be/9iWRRx7nZlU?feature=shared)


### PR DESCRIPTION
Update to the OBO Academy schedule to list the Uberon presentation happening on May 14, 2024. 