### PR TITLE
Update schedule for Oct to Dec 2024

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -28,9 +28,9 @@ _Note: this is tentative and subject to change_
 
 | Date | Lesson | Notes | Recordings |
 | --- | --- | --- | --- |
-| 2024/12/10 | _Topic Coming Soon_ | |  |
-| 2024/11/12 | _Topic Coming Soon_ |  |  |
-| 2024/10/15 | _Topic Coming Soon_ |  |  |
+| 2024/12/10 | Rare Diseases & Ontologies | Eric Sid, NIH/NCATS |  |
+| 2024/11/12 | Hands On Workshop Part 2: OntoGPT | Harry Caufield, LBNL |  |
+| 2024/10/15 | Hands On Workshop Part 1: OntoGPT | Harry Caufield, LBNL |  |
 | July to Sept 2024 | _No Meeting_ | Enjoy Summer break! |  |
 | 2024/06/25 | Structures and Instructors: Applying the Strengths of Large Language Models to Biomedical Informatics | Harry Caufield, LBNL | [Here](https://youtu.be/wJvKMIyOpfo?feature=shared) |
 | 2024/05/14 | Introduction to the legendary [Uberon Anatomy ontology](https://obophenotype.github.io/uberon/) | Damien Goutte-Gattat and Nico Matentzoglu | [Here](https://youtu.be/HmFhTk0Bahs?si=q4cfg1lYx7sTqE0M) |


### PR DESCRIPTION
Updated the OBO Academy schedule to reflect the schedule for October to December 2024. 
- October 15: Harry lead; Hands on Tutorial part 1: OntoGPT
- November 12: Harry lead; Hands on Tutorial part 2: OntoGPT
- December 10: Eric Rare Disease presentation