### PR TITLE
Update monarch-obo-training.md

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -28,7 +28,7 @@ _Note: this is tentative and subject to change_
 
 | Date | Lesson | Notes | Recordings |
 | --- | --- | --- | --- |
-| 2024/12/10 | Rare Diseases & Ontologies | Eric Sid, NIH/NCATS |  |
+| 2025/02/04 |  |  |  |
 | 2024/11/12 | Hands On Workshop Part 2: OntoGPT | Unforuntately, we had technical difficulties during this workshop. We will reschedule Part 2 for sometime in 2025. |  |
 | 2024/10/15 | Hands On Workshop Part 1: OntoGPT | Harry Caufield, LBNL | [Here](https://youtu.be/ezFIgY0LE4A?si=Pwuoq3VkvVNjon09)  |
 | July to Sept 2024 | _No Meeting_ | Enjoy Summer break! |  |


### PR DESCRIPTION
Update schedule to remove Eric's talk from Dec 2024 (it is on the Monarch Seminar Series schedule instead). And also listed the first OBO Academy date for 2025.