### PR TITLE
Fix broken link for types of taxon restrictions

### DIFF
--- a/docs/howto/add-taxon-restrictions.md
+++ b/docs/howto/add-taxon-restrictions.md
@@ -1,6 +1,6 @@
 # Adding taxon restrictions
 
-Before adding taxon restrictions, please review the [types of taxon restrictions documentation](https://oboacademy.github.io/obook/explanation/taxon-constraints-explainer/?h=taxon+restric#types-of-taxon-restrictions).
+Before adding taxon restrictions, please review the [types of taxon restrictions documentation](../explanation/taxon-constraints-explainer/#types-of-taxon-restrictions).
 
 See [Daily Workflow](daily-curator-workflow.md) for creating branches and basic Protégé instructions.
 

--- a/docs/howto/add-taxon-restrictions.md
+++ b/docs/howto/add-taxon-restrictions.md
@@ -1,6 +1,6 @@
 # Adding taxon restrictions
 
-Before adding taxon restrictions, please review the [types of taxon restrictions documentation](../explanation/taxon-constraints-explainer/#Types-of-Taxon-Restrictions).
+Before adding taxon restrictions, please review the [types of taxon restrictions documentation](https://oboacademy.github.io/obook/explanation/taxon-constraints-explainer/?h=taxon+restric#types-of-taxon-restrictions).
 
 See [Daily Workflow](daily-curator-workflow.md) for creating branches and basic Protégé instructions.
 


### PR DESCRIPTION
The previous link for taxon restrictions documentation was broken, I have provided a valid link.