### PR TITLE
Update monarch-obo-training.md

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -30,8 +30,7 @@ _Note: this is tentative and subject to change_
 
 | Date | Lesson | Presenter / Notes | Recordings |
 | --- | --- | --- | --- |
-| August to Sept 2025 | _No Meeting_ | Enjoy Summer break! |  |
-| 2025/07/22 | TBD |  | 
+| July to Sept 2025 | _No Meeting_ | Enjoy Summer break! |  |
 | 2025/06/24 | [From Fuzzy to Clear: Writing Ontology Definitions That Work](https://docs.google.com/presentation/d/1UsjN7OzSXsRMy1v7ucvMBmlUF0VUau3pJYXV3wXMEzs/edit?slide=id.p#slide=id.p) <br> This is a tutorial for curators at any level.| Sabrina Toro, UNC-Chapel Hill  | [here](https://youtu.be/jhJWv-2d-S4?si=KPuHA5wXTWT_n0Q4)
 | 2025/06/09 | Using AI coding apps for ontology developers. [Tutorial material](https://ai4curation.github.io/aidocs/tutorials/ontology-editing-with-ai/) | Chris Mungall, LBNL | [Here](https://youtu.be/4nyeGFACPKI?si=56v1jVXT8VYqZXUn) |
 | 2025/04/08 | Introduction to developing agentic workflows for semantic engineers. [Tutorial material](https://github.com/cmungall/agent-tutorial) | Chris Mungall, LBNL | [Here](https://youtu.be/Ml0YVjKnZnE?si=BVLomWUjPoAqH5oG) | 


### PR DESCRIPTION
Update the OBO academy schedule: 
Removed July 2025 seminar and extended the summer break.